### PR TITLE
fix: enable member pages for engineering staff

### DIFF
--- a/plugins/members/index.js
+++ b/plugins/members/index.js
@@ -112,7 +112,7 @@ module.exports = function membersPlugin(context, options) {
 
       // Create dynamic routes for member pages (only for researchers)
       for (const member of members) {
-        if (member.slug && member.type === 'researcher') {
+        if (member.slug && (member.type === 'researcher' || member.type === 'engineer')) {
           const authorShortName = getAuthorShortName(member.name);
           const memberPublications = getPublicationsByAuthorShortName(publications, authorShortName);
 


### PR DESCRIPTION
# Enable Member Pages for Engineering Staff

## Description
Currently, the website shows clickable links for both researchers and engineering staff members, but only generates individual pages for researchers. This causes broken links when users click on engineering staff member profiles. This PR fixes this inconsistency by enabling page generation for both researchers and engineering staff.

## Changes Made
- Modified the member page generation logic in `plugins/members/index.js` to create pages for both researcher and engineer member types
- No UI changes were needed as the frontend already shows clickable links for both types

## Testing Done
- Verified that clicking on engineering staff member profiles now leads to their individual pages
- Confirmed that existing researcher pages continue to work as expected
- Checked that the page layout and content is consistent across both member types