### PR TITLE
feat: add ordering feature for projects with 'order' field in YAML 

### DIFF
--- a/data/projects/AGENTS.md
+++ b/data/projects/AGENTS.md
@@ -25,12 +25,18 @@ Optional fields
 - `isOurs` (boolean)
 - `sourceLink` (external repo URL)
 - `tutorialLink` (docs link)
+- `order` (number): controls display ordering. Lower numbers appear first; items without `order` appear after all ordered items and are sorted alphabetically by `name`.
 
 Rendering
 
 - Projects list page: `src/pages/research/projects/index.mdx` via `ProjectList`.
 - Project cards/items: `src/components/projects/`.
 - Data is loaded by `plugins/projects/` and available through global data.
+
+Ordering
+
+- Projects are ordered by ascending `order` when present, then by `name`.
+- The loader (`plugins/projects`) applies this sort globally; `ProjectList` also applies the same rule when `isSorted` is set.
 
 Per-project content (MDX)
 
@@ -56,6 +62,7 @@ sourceLink: https://github.com/grc-iit/chronolog
 status: active
 tutorialLink: /docs/category/chronolog
 type: funded
+order: 1
 ```
 
 Checklist

--- a/data/projects/chronolog.yaml
+++ b/data/projects/chronolog.yaml
@@ -9,6 +9,7 @@ shortDescription: >-
 link: /research/projects/chronolog
 isFeatured: true
 isOurs: true
+order: 2
 researchStatus: testing
 sourceLink: https://github.com/grc-iit/chronolog
 status: active

--- a/data/projects/coeus.yaml
+++ b/data/projects/coeus.yaml
@@ -9,6 +9,7 @@ shortDescription: >-
 link: /research/projects/coeus
 isFeatured: true
 isOurs: true
+order: 7
 researchStatus: r&d
 status: active
 type: funded

--- a/data/projects/dayu.yaml
+++ b/data/projects/dayu.yaml
@@ -8,6 +8,7 @@ shortDescription: >-
 link: /research/projects/dayu
 isFeatured: false
 isOurs: true
+order: 4
 researchStatus: ready
 status: active
 type: funded

--- a/data/projects/dtio.yaml
+++ b/data/projects/dtio.yaml
@@ -7,6 +7,7 @@ shortDescription: >-
 link: /research/projects/dtio
 isFeatured: false
 isOurs: true
+order: 6
 researchStatus: testing
 status: active
 type: funded

--- a/data/projects/hermes.yaml
+++ b/data/projects/hermes.yaml
@@ -8,6 +8,7 @@ shortDescription: >-
 link: /research/projects/hermes
 isFeatured: true
 isOurs: true
+order: 3
 researchStatus: ready
 sourceLink: https://github.com/HDFGroup/hermes
 status: active

--- a/data/projects/iowarp.yaml
+++ b/data/projects/iowarp.yaml
@@ -9,6 +9,7 @@ shortDescription: >-
 link: /research/projects/iowarp
 isFeatured: true
 isOurs: true
+order: 1
 researchStatus: r&d
 sourceLink: https://github.com/iowarp
 status: active

--- a/data/projects/labios.yaml
+++ b/data/projects/labios.yaml
@@ -7,6 +7,7 @@ shortDescription: >-
 link: /research/projects/labios
 isFeatured: false
 isOurs: true
+order: 5
 researchStatus: r&d
 sourceLink: https://github.com/grc-iit/labios
 status: active

--- a/data/projects/wisio.yaml
+++ b/data/projects/wisio.yaml
@@ -8,6 +8,7 @@ shortDescription: >-
 link: /research/projects/wisio
 isFeatured: false
 isOurs: true
+order: 8
 researchStatus: ready
 sourceLink: https://github.com/grc-iit/wisio
 status: active

--- a/plugins/projects/index.js
+++ b/plugins/projects/index.js
@@ -12,8 +12,18 @@ function loadProjects(siteDir) {
     return yaml.load(content);
   });
 
-  // Sort projects by name for consistent ordering
-  projects.sort((a, b) => a.name.localeCompare(b.name));
+  // Sort projects: first by explicit ascending 'order' (if present), then by name
+  projects.sort((a, b) => {
+    const hasOrderA = typeof a.order === 'number';
+    const hasOrderB = typeof b.order === 'number';
+    if (hasOrderA && hasOrderB) {
+      if (a.order !== b.order) return a.order - b.order;
+      return (a.name || '').localeCompare(b.name || '');
+    }
+    if (hasOrderA) return -1;
+    if (hasOrderB) return 1;
+    return (a.name || '').localeCompare(b.name || '');
+  });
 
   return projects;
 }

--- a/src/components/projects/ProjectList.tsx
+++ b/src/components/projects/ProjectList.tsx
@@ -19,7 +19,17 @@ export default function ProjectList({
     <div className="container">
       <div className="row">
         {(isSorted
-          ? projects.sort((p1, p2) => p1.name.localeCompare(p2.name))
+          ? [...projects].sort((a, b) => {
+              const hasOrderA = typeof a.order === "number";
+              const hasOrderB = typeof b.order === "number";
+              if (hasOrderA && hasOrderB) {
+                if (a.order !== b.order) return (a.order as number) - (b.order as number);
+                return a.name.localeCompare(b.name);
+              }
+              if (hasOrderA) return -1;
+              if (hasOrderB) return 1;
+              return a.name.localeCompare(b.name);
+            })
           : projects
         ).map((project) => (
           <ProjectItem key={project.id} project={project} />

--- a/src/types.ts
+++ b/src/types.ts
@@ -80,6 +80,7 @@ export type Project = {
   status: "active" | "archived";
   tutorialLink?: string;
   type: "funded" | "student";
+  order?: number;
 };
 
 export type PublicationAuthor =


### PR DESCRIPTION
This pull request introduces an explicit `order` field to project metadata and updates the sorting logic for project listings to prioritize this field. Projects with a lower `order` value are displayed first; projects without an `order` are sorted alphabetically after all ordered projects. These changes ensure more flexible and consistent project ordering across the site.

**Ordering improvements:**

* Added an `order` field to the project metadata schema and documentation, describing its purpose and usage for display ordering. [[1]](diffhunk://#diff-0fab979c47d897b206c89d99c8444a9c9c616f05fdae0405ef564fb5e8afc9cbR28-R40) [[2]](diffhunk://#diff-c54113cf61ec99691748a3890bfbeb00e10efb3f0a76f03a0fd9ec49072e410aR83)
* Updated the loader (`plugins/projects/index.js`) to sort projects first by ascending `order`, then by `name`.
* Modified the `ProjectList` component to apply the same sorting logic when `isSorted` is enabled.

**Project metadata updates:**

* Added explicit `order` values to multiple project YAML files (`chronolog.yaml`, `coeus.yaml`, `dayu.yaml`, `dtio.yaml`, `hermes.yaml`, `iowarp.yaml`, `labios.yaml`, `wisio.yaml`) and to the AGENTS project entry, establishing the desired display order. [[1]](diffhunk://#diff-0fab979c47d897b206c89d99c8444a9c9c616f05fdae0405ef564fb5e8afc9cbR65) [[2]](diffhunk://#diff-8b989fc48600548cf577c1577755f9bbda7682b423558edc9e96445c1a6f6e47R12) [[3]](diffhunk://#diff-9e1d6a08ac04b631cec58fb74ae2066519c1e74d991933d210d51f8bfc43bbfeR12) [[4]](diffhunk://#diff-57b8bfb41ed8468d4003bd476bf032efb6880114baf06ef517492c1365ef9422R11) [[5]](diffhunk://#diff-eff1e8025ea4cabc794b5be3e6653c708b6d150bf4edbe51b43178a89639e908R10) [[6]](diffhunk://#diff-44caa5f33cf0473a75e2db4ca59c6145258539c4bd9a377dd8a47f9d1def7042R11) [[7]](diffhunk://#diff-2faae631b14be241fc71aa715217fbc59d07bba3d5148a9959a6dad218fc4474R12) [[8]](diffhunk://#diff-65e474614991f606e5cd69b3b8378adbbea8464ec5dde714ec19a637e1a077f0R10) [[9]](diffhunk://#diff-4e9ce52e9c15387e0ec02d2743ab64512ed1fb51d348deb1abf1d0a9e5e5c2a0R11)